### PR TITLE
Merging btw-add-home with DEER

### DIFF
--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -993,11 +993,11 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    The client will use DEER [I-D.pauly-add-deer] to discover the DoH
    templates supported by the DNS server at the Locator address.  In
    addition to the checks included in DEER, clients should verify the
-   ADN matches the hostname in the DEER-provided templates.  The IP
-   address of the DEER-discovered resolver may differ from the Locator
-   field value so long as the domain name matches the ADN.  This will
-   allow ISPs to have local forwarders send clients to off-network but
-   ISP-owned resolvers whose IP address may not be known in advance.
+   ADN is valid for the certificate provided by the DoH resolver.  The
+   IP address of the DEER-discovered resolver may differ from the
+   Locator field value so long as the domain name matches the ADN.  This
+   will allow home networks to refer clients to resolvers known by name
+   even if the current IP address of that resolver is not known.
 
    Alternatively, dedicated DHCP/RA options may be defined to convey an
    URI template to avoid additional network traffic to bootstrap DoH
@@ -1214,9 +1214,9 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
    The DHCP/RA option to discover DoH templates from DHCP or RA options
    (should the WG pursue that approach pending feedback) takes
-   precedence over DEER since it uses unencrypted DNS to an external DNS
-   resolver, which is susceptible to both internal and external attacks
-   whereas DHCP/RA is only vulnerable to internal attacks.
+   precedence over DEER since DEER uses unencrypted DNS to an external
+   DNS resolver, which is susceptible to both internal and external
+   attacks whereas DHCP/RA is only vulnerable to internal attacks.
 
 9.  Security Considerations
 

--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -5,14 +5,14 @@
 ADD                                                         M. Boucadair
 Internet-Draft                                                    Orange
 Intended status: Standards Track                                T. Reddy
-Expires: July 9, 2021                                             McAfee
+Expires: July 10, 2021                                            McAfee
                                                                  D. Wing
                                                                   Citrix
                                                                  N. Cook
                                                             Open-Xchange
                                                                T. Jensen
                                                                Microsoft
-                                                         January 5, 2021
+                                                         January 6, 2021
 
 
 DHCP and Router Advertisement Options for Encrypted DNS Discovery within
@@ -45,7 +45,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 9, 2021.
+   This Internet-Draft will expire on July 10, 2021.
 
 
 
@@ -53,7 +53,7 @@ Status of This Memo
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 1]
+Boucadair, et al.         Expires July 10, 2021                 [Page 1]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 2]
+Boucadair, et al.         Expires July 10, 2021                 [Page 2]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -119,7 +119,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  26
      13.1.  Normative References . . . . . . . . . . . . . . . . . .  26
      13.2.  Informative References . . . . . . . . . . . . . . . . .  27
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  30
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  31
 
 1.  Introduction
 
@@ -165,7 +165,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 3]
+Boucadair, et al.         Expires July 10, 2021                 [Page 3]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -221,7 +221,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 4]
+Boucadair, et al.         Expires July 10, 2021                 [Page 4]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -277,7 +277,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 5]
+Boucadair, et al.         Expires July 10, 2021                 [Page 5]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -333,7 +333,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 6]
+Boucadair, et al.         Expires July 10, 2021                 [Page 6]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -389,7 +389,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 7]
+Boucadair, et al.         Expires July 10, 2021                 [Page 7]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -445,7 +445,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 8]
+Boucadair, et al.         Expires July 10, 2021                 [Page 8]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -501,7 +501,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                  [Page 9]
+Boucadair, et al.         Expires July 10, 2021                 [Page 9]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -557,7 +557,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 10]
+Boucadair, et al.         Expires July 10, 2021                [Page 10]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -613,7 +613,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 11]
+Boucadair, et al.         Expires July 10, 2021                [Page 11]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -669,7 +669,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 12]
+Boucadair, et al.         Expires July 10, 2021                [Page 12]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -725,7 +725,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 13]
+Boucadair, et al.         Expires July 10, 2021                [Page 13]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -781,7 +781,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 14]
+Boucadair, et al.         Expires July 10, 2021                [Page 14]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -837,7 +837,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 15]
+Boucadair, et al.         Expires July 10, 2021                [Page 15]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -893,7 +893,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 16]
+Boucadair, et al.         Expires July 10, 2021                [Page 16]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -949,7 +949,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 17]
+Boucadair, et al.         Expires July 10, 2021                [Page 17]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -979,7 +979,8 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    contact that DoH resolver to retrieve the list of supported DoH
    services using DEER [I-D.pauly-add-deer].  This will allow the client
    to discover the resolver's supported DoH templates (or DoH resolvers
-   the discovered resolver designates) using DNS SVCB queries.
+   that the discovered resolver designates) using DNS SVCB queries
+   [I-D.schwartz-svcb-dns].
 
    Let's suppose that a host has discovered an encrypted DNS server that
    is DoH-capable.  The host has also discovered the following
@@ -1004,8 +1005,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-
-Boucadair, et al.         Expires July 9, 2021                 [Page 18]
+Boucadair, et al.         Expires July 10, 2021                [Page 18]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1061,7 +1061,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 19]
+Boucadair, et al.         Expires July 10, 2021                [Page 19]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1117,7 +1117,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 20]
+Boucadair, et al.         Expires July 10, 2021                [Page 20]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1173,7 +1173,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 21]
+Boucadair, et al.         Expires July 10, 2021                [Page 21]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1208,7 +1208,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    discovered using DHCP/RA, such hosts will have to fallback to use
    DEER as defined in [I-D.pauly-add-deer] to discover the encrypted DNS
    server and to retrieve the list of supported DoH services using the
-   SVCB RRtype [I-D.pauly-add-deer] without verifying the hostname of
+   SVCB RRtype [I-D.schwartz-svcb-dns] without verifying the hostname of
    discovered templates with the ADN.  Other guidance in DEER relating
    to resolver verification must be followed in this case.
 
@@ -1229,7 +1229,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 22]
+Boucadair, et al.         Expires July 10, 2021                [Page 22]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1285,7 +1285,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 23]
+Boucadair, et al.         Expires July 10, 2021                [Page 23]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1341,7 +1341,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 24]
+Boucadair, et al.         Expires July 10, 2021                [Page 24]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1397,7 +1397,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 25]
+Boucadair, et al.         Expires July 10, 2021                [Page 25]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1453,7 +1453,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 26]
+Boucadair, et al.         Expires July 10, 2021                [Page 26]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1509,7 +1509,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 9, 2021                 [Page 27]
+Boucadair, et al.         Expires July 10, 2021                [Page 27]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -1539,6 +1539,11 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               DNS Discovery", draft-pusateri-dhc-dns-driu-00 (work in
               progress), July 2018.
 
+   [I-D.schwartz-svcb-dns]
+              Schwartz, B., "Service Binding Mapping for DNS Servers",
+              draft-schwartz-svcb-dns-01 (work in progress), August
+              2020.
+
    [Krack]    The Unicode Consortium, "Key Reinstallation Attacks",
               2017, <https://www.krackattacks.com/>.
 
@@ -1555,20 +1560,20 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               DOI 10.17487/RFC3552, July 2003,
               <https://www.rfc-editor.org/info/rfc3552>.
 
+
+
+
+
+
+Boucadair, et al.         Expires July 10, 2021                [Page 28]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    [RFC3646]  Droms, R., Ed., "DNS Configuration options for Dynamic
               Host Configuration Protocol for IPv6 (DHCPv6)", RFC 3646,
               DOI 10.17487/RFC3646, December 2003,
               <https://www.rfc-editor.org/info/rfc3646>.
-
-
-
-
-
-
-Boucadair, et al.         Expires July 9, 2021                 [Page 28]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
    [RFC6092]  Woodyatt, J., Ed., "Recommended Simple Security
               Capabilities in Customer Premises Equipment (CPE) for
@@ -1614,17 +1619,17 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               Layer Security (TLS)", RFC 7858, DOI 10.17487/RFC7858, May
               2016, <https://www.rfc-editor.org/info/rfc7858>.
 
+
+
+Boucadair, et al.         Expires July 10, 2021                [Page 29]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    [RFC7969]  Lemon, T. and T. Mrugalski, "Customizing DHCP
               Configuration on the Basis of Network Topology", RFC 7969,
               DOI 10.17487/RFC7969, October 2016,
               <https://www.rfc-editor.org/info/rfc7969>.
-
-
-
-Boucadair, et al.         Expires July 9, 2021                 [Page 29]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
    [RFC8146]  Harkins, D., "Adding Support for Salted Password Databases
               to EAP-pwd", RFC 8146, DOI 10.17487/RFC8146, April 2017,
@@ -1667,20 +1672,17 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               network protocols; Stage 3 (Release 16)", December 2019,
               <http://www.3gpp.org/DynaReport/24008.htm>.
 
-Authors' Addresses
 
 
 
 
 
-
-
-
-
-Boucadair, et al.         Expires July 9, 2021                 [Page 30]
+Boucadair, et al.         Expires July 10, 2021                [Page 30]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
+
+Authors' Addresses
 
    Mohamed Boucadair
    Orange
@@ -1731,6 +1733,4 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-
-
-Boucadair, et al.         Expires July 9, 2021                 [Page 31]
+Boucadair, et al.         Expires July 10, 2021                [Page 31]

--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -1386,14 +1386,14 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    Many thanks to Christian Jacquenet and Michael Richardson for the
    review.
 
-   Thanks to Tommy Jensen, Stephen Farrell, Martin Thomson, Vittorio
-   Bertola, Stephane Bortzmeyer, Ben Schwartz, and Iain Sharp for the
-   comments.
+   Thanks to Stephen Farrell, Martin Thomson, Vittorio Bertola, Stephane
+   Bortzmeyer, Ben Schwartz, and Iain Sharp for the comments.
 
    Thanks to Mark Nottingham for the feedback on HTTP redirection.
 
-
-
+   The use of DHCP to retrieve an authentication domain name was
+   discussed in Section 7.3.1 of [RFC8310] and
+   [I-D.pusateri-dhc-dns-driu].
 
 
 
@@ -1401,10 +1401,6 @@ Boucadair, et al.         Expires July 9, 2021                 [Page 25]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
-
-   The use of DHCP to retrieve an authentication domain name was
-   discussed in Section 7.3.1 of [RFC8310] and
-   [I-D.pusateri-dhc-dns-driu].
 
 12.  Contributing Authors
 
@@ -1450,6 +1446,10 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+
 
 
 

--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -1214,7 +1214,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
    The DHCP/RA option to discover DoH templates from DHCP or RA options
    (should the WG pursue that approach pending feedback) takes
-   precedence over DEER since it may use unencrypted DNS to a public
+   precedence over DEER since it uses unencrypted DNS to an external DNS
    resolver, which is susceptible to both internal and external attacks
    whereas DHCP/RA is only vulnerable to internal attacks.
 

--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -993,11 +993,11 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    The client will use DEER [I-D.pauly-add-deer] to discover the DoH
    templates supported by the DNS server at the Locator address.  In
    addition to the checks included in DEER, clients should verify the
-   ADN is valid for the certificate provided by the DoH resolver.  The
-   IP address of the DEER-discovered resolver may differ from the
-   Locator field value so long as the domain name matches the ADN.  This
-   will allow home networks to refer clients to resolvers known by name
-   even if the current IP address of that resolver is not known.
+   ADN is valid for the certificate provided by the DoH resolver.
+   However, the IP address of the DEER-discovered resolver may differ
+   from the Locator field value.  This will allow home networks to refer
+   clients to resolvers known by name even if the current IP address of
+   that resolver is not known.
 
    Alternatively, dedicated DHCP/RA options may be defined to convey an
    URI template to avoid additional network traffic to bootstrap DoH

--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -5,12 +5,14 @@
 ADD                                                         M. Boucadair
 Internet-Draft                                                    Orange
 Intended status: Standards Track                                T. Reddy
-Expires: May 6, 2021                                              McAfee
+Expires: July 9, 2021                                             McAfee
                                                                  D. Wing
                                                                   Citrix
                                                                  N. Cook
                                                             Open-Xchange
-                                                        November 2, 2020
+                                                               T. Jensen
+                                                               Microsoft
+                                                         January 5, 2021
 
 
 DHCP and Router Advertisement Options for Encrypted DNS Discovery within
@@ -43,20 +45,23 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 6, 2021.
+   This Internet-Draft will expire on July 9, 2021.
+
+
+
+
+
+
+
+Boucadair, et al.         Expires July 9, 2021                  [Page 1]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
 Copyright Notice
 
-   Copyright (c) 2020 IETF Trust and the persons identified as the
+   Copyright (c) 2021 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                  [Page 1]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
@@ -92,29 +97,29 @@ Table of Contents
        7.1.3.  Auto-Upgrade Based on Domains and their Subdomains  .  20
      7.2.  Unmanaged CPEs  . . . . . . . . . . . . . . . . . . . . .  21
    8.  Legacy CPEs . . . . . . . . . . . . . . . . . . . . . . . . .  22
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  23
-     9.1.  Spoofing Attacks  . . . . . . . . . . . . . . . . . . . .  23
-     9.2.  Deletion Attacks  . . . . . . . . . . . . . . . . . . . .  24
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  22
+     9.1.  Spoofing Attacks  . . . . . . . . . . . . . . . . . . . .  22
+     9.2.  Deletion Attacks  . . . . . . . . . . . . . . . . . . . .  23
      9.3.  Passive Attacks . . . . . . . . . . . . . . . . . . . . .  24
      9.4.  Wireless Security - Authentication Attacks  . . . . . . .  24
-   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
-     10.1.  DHCPv6 Options . . . . . . . . . . . . . . . . . . . . .  25
+   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  24
+     10.1.  DHCPv6 Options . . . . . . . . . . . . . . . . . . . . .  24
      10.2.  DHCP Option  . . . . . . . . . . . . . . . . . . . . . .  25
      10.3.  RA Options . . . . . . . . . . . . . . . . . . . . . . .  25
+
+
+
+Boucadair, et al.         Expires July 9, 2021                  [Page 2]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    11. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
    12. Contributing Authors  . . . . . . . . . . . . . . . . . . . .  26
    13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  26
      13.1.  Normative References . . . . . . . . . . . . . . . . . .  26
      13.2.  Informative References . . . . . . . . . . . . . . . . .  27
-
-
-
-Boucadair, et al.          Expires May 6, 2021                  [Page 2]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  31
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  30
 
 1.  Introduction
 
@@ -160,14 +165,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                  [Page 3]
+Boucadair, et al.         Expires July 9, 2021                  [Page 3]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
              (a) Fixed Networks
@@ -221,9 +221,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                  [Page 4]
+Boucadair, et al.         Expires July 9, 2021                  [Page 4]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    supplied by their ISP) to configure their favorite DNS servers.  This
@@ -277,9 +277,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                  [Page 5]
+Boucadair, et al.         Expires July 9, 2021                  [Page 5]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 3.1.1.  Direct DNS
@@ -333,9 +333,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                  [Page 6]
+Boucadair, et al.         Expires July 9, 2021                  [Page 6]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    like DHCP or a specific Router Advertisement message.  In such
@@ -389,9 +389,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                  [Page 7]
+Boucadair, et al.         Expires July 9, 2021                  [Page 7]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    (a)
@@ -445,9 +445,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                  [Page 8]
+Boucadair, et al.         Expires July 9, 2021                  [Page 8]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
                     ,--,--,--.                    ,--,--,--.
@@ -501,9 +501,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                  [Page 9]
+Boucadair, et al.         Expires July 9, 2021                  [Page 9]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    To avoid adding a dependency on another server to resolve the ADN,
@@ -557,9 +557,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 10]
+Boucadair, et al.         Expires July 9, 2021                 [Page 10]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 4.1.  DHCPv6 Encrypted DNS Options
@@ -613,9 +613,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 11]
+Boucadair, et al.         Expires July 9, 2021                 [Page 11]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
       To keep the packet small, if more than one encrypted DNS type
@@ -669,9 +669,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 12]
+Boucadair, et al.         Expires July 9, 2021                 [Page 12]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    o  Option-code: OPTION_V6_ENC_ADD (TBA2, see Section 10.1)
@@ -725,9 +725,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 13]
+Boucadair, et al.         Expires July 9, 2021                 [Page 13]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 4.2.  DHCPv4 Encrypted DNS Option
@@ -781,9 +781,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 14]
+Boucadair, et al.         Expires July 9, 2021                 [Page 14]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
            0     8     16    24    32    40    48
@@ -837,9 +837,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 15]
+Boucadair, et al.         Expires July 9, 2021                 [Page 15]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
         0                   1                   2                   3
@@ -893,9 +893,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 16]
+Boucadair, et al.         Expires July 9, 2021                 [Page 16]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    addresses share the same Lifetime value.  Simialr to [RFC8106], if it
@@ -949,9 +949,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 17]
+Boucadair, et al.         Expires July 9, 2021                 [Page 17]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    o  Enc DNS Flags (Encrypted DNS Flags): Indicates the type(s) of the
@@ -976,9 +976,10 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    server.
 
    Upon discovery of a DoH resolver (Section 4), the DoH client may
-   contact that DoH server to retrieve the list of supported DoH
-   services using the well-known URI.  DoH clients repeats that request
-   regularly to retrieve an updated list of supported DoH services.
+   contact that DoH resolver to retrieve the list of supported DoH
+   services using DEER [I-D.pauly-add-deer].  This will allow the client
+   to discover the resolver's supported DoH templates (or DoH resolvers
+   the discovered resolver designates) using DNS SVCB queries.
 
    Let's suppose that a host has discovered an encrypted DNS server that
    is DoH-capable.  The host has also discovered the following
@@ -988,26 +989,25 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
    o  Locator: 2001:db8:1::1
 
-   The client requests "https://doh.example.com/.well-known/resinfo" to
-   retrieve the list of the URI Templates associated with this
-   discovered server.
+   The client will use DEER [I-D.pauly-add-deer] to discover the DoH
+   templates supported by the DNS server at the Locator address.  In
+   addition to the checks included in DEER, clients should verify the
+   ADN matches the hostname in the DEER-provided templates.  The IP
+   address of the DEER-discovered resolver may differ from the Locator
+   field value so long as the domain name matches the ADN.  This will
+   allow ISPs to have local forwarders send clients to off-network but
+   ISP-owned resolvers whose IP address may not be known in advance.
 
    Alternatively, dedicated DHCP/RA options may be defined to convey an
-   URI template.  An example of such option is depicted in Figure 16.
+   URI template to avoid additional network traffic to bootstrap DoH
+   configuration.  An example of such option is depicted in Figure 16.
 
 
 
 
-
-
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 18]
+Boucadair, et al.         Expires July 9, 2021                 [Page 18]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
        0                   1                   2                   3
@@ -1061,9 +1061,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 19]
+Boucadair, et al.         Expires July 9, 2021                 [Page 19]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
       within subjectAltName entry in the server certificate conveyed in
@@ -1117,9 +1117,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 20]
+Boucadair, et al.         Expires July 9, 2021                 [Page 20]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    shown in Figure 17, the auto-upgrade to a rogue server advertising
@@ -1173,9 +1173,9 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 21]
+Boucadair, et al.         Expires July 9, 2021                 [Page 21]
 
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
    Figure 18 illustrates an example of an unmanaged CPE hosting a
@@ -1205,34 +1205,18 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    Hosts serviced by legacy CPEs that can't be upgraded to support the
    options defined in Section 4 won't be able to learn the encrypted DNS
    server hosted by the ISP, in particular.  If the ADN is not
-   discovered using DHCP/RA, such hosts will have to fallback to use the
-   special-use domain name defined in [I-D.pp-add-resinfo] to discover
-   the encrypted DNS server and to retrieve the list of supported DoH
-   services using the RESINFO RRtype [I-D.pp-add-resinfo].
+   discovered using DHCP/RA, such hosts will have to fallback to use
+   DEER as defined in [I-D.pauly-add-deer] to discover the encrypted DNS
+   server and to retrieve the list of supported DoH services using the
+   SVCB RRtype [I-D.pauly-add-deer] without verifying the hostname of
+   discovered templates with the ADN.  Other guidance in DEER relating
+   to resolver verification must be followed in this case.
 
-   If the Do53 and Encrypted DNS servers are hosted on different public
-   IP addresses, the DNS server certificate can include the IP address
-   of the Do53 server in the subjectAltName extension.  After validating
-   the server certificate, the client can retrieve the IP address in the
-   certificate to identify that both Do53 and Encrypted DNS servers are
-   operated by the same entity.
-
-   If the Do53 and Encrypted DNS server are hosted on a private IP
-   address, they should use the same private IP address to prove to the
-   client they are operated by the same entity.
-
-   The DHCP/RA option to discover ADN takes precedence over special-use
-   domain name since the special-use domain name is susceptible to both
-   internal and external attacks whereas DHCP/RA is only vulnerable to
-   internal attacks.
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 22]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
+   The DHCP/RA option to discover DoH templates from DHCP or RA options
+   (should the WG pursue that approach pending feedback) takes
+   precedence over DEER since it may use unencrypted DNS to a public
+   resolver, which is susceptible to both internal and external attacks
+   whereas DHCP/RA is only vulnerable to internal attacks.
 
 9.  Security Considerations
 
@@ -1242,6 +1226,14 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    within the LAN.  Unless mitigated (described below), the content of
    DHCP and RA messages can be spoofed or modified by active attackers,
    such as compromised devices within the home network.  An active
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 22]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    attacker (Section 3.3 of [RFC3552]) can spoof the DHCP/RA response to
    provide the attacker's Encrypted DNS server.  Note that such an
    attacker can launch other attacks as discussed in Section 22 of
@@ -1279,17 +1271,6 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    behavior adheres to REQ#8 in [RFC6092]; it MUST apply for both IPv4
    and IPv6.
 
-
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 23]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
 9.2.  Deletion Attacks
 
    If the DHCP responses or RAs are dropped by the attacker, the client
@@ -1298,6 +1279,16 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    document.
 
    Note that deletion attack is not specific to DHCP/RA.
+
+
+
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 23]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
 9.3.  Passive Attacks
 
@@ -1334,24 +1325,26 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    keys can be created for each such device and WPA-PSK is used (e.g.,
    [PSK]).
 
-
-
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 24]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
 10.  IANA Considerations
 
 10.1.  DHCPv6 Options
 
    IANA is requested to assign the following new DHCPv6 Option Code in
    the registry maintained in [DHCPV6].
+
+
+
+
+
+
+
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 24]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    +-------+-------------------+---------+------------+----------------+
    | Value | Description       | Client  | Singleton  | Reference      |
@@ -1393,20 +1386,21 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    Many thanks to Christian Jacquenet and Michael Richardson for the
    review.
 
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 25]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
    Thanks to Tommy Jensen, Stephen Farrell, Martin Thomson, Vittorio
    Bertola, Stephane Bortzmeyer, Ben Schwartz, and Iain Sharp for the
    comments.
 
    Thanks to Mark Nottingham for the feedback on HTTP redirection.
+
+
+
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 25]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    The use of DHCP to retrieve an authentication domain name was
    discussed in Section 7.3.1 of [RFC8310] and
@@ -1448,16 +1442,6 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               RFC 8106, DOI 10.17487/RFC8106, March 2017,
               <https://www.rfc-editor.org/info/rfc8106>.
 
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 26]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
    [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
               Writing an IANA Considerations Section in RFCs", BCP 26,
               RFC 8126, DOI 10.17487/RFC8126, June 2017,
@@ -1466,6 +1450,13 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 26]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    [RFC8310]  Dickinson, S., Gillmor, D., and T. Reddy, "Usage Profiles
               for DNS over TLS and DNS over DTLS", RFC 8310,
@@ -1504,25 +1495,24 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               Dragonfly Handshake of WPA3 and EAP-pwd",
               <https://papers.mathyvanhoef.com/dragonblood.pdf>.
 
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 27]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
    [Evil-Twin]
               The Unicode Consortium, "Evil twin (wireless networks)",
               <https://en.wikipedia.org/wiki/
               Evil_twin_(wireless_networks)>.
 
    [I-D.box-add-requirements]
-              Box, C., Pauly, T., Wood, C., and T. Reddy.K,
+              Box, C., Pauly, T., Wood, C., Reddy.K, T., and D. Migault,
               "Requirements for Adaptive DNS Discovery", draft-box-add-
-              requirements-00 (work in progress), September 2020.
+              requirements-01 (work in progress), November 2020.
+
+
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 27]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    [I-D.ietf-dnsop-terminology-ter]
               Hoffman, P., "Terminology for DNS Transports and
@@ -1539,10 +1529,10 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               Routers", draft-ietf-v6ops-rfc7084-bis-04 (work in
               progress), June 2017.
 
-   [I-D.pp-add-resinfo]
-              Sood, P. and P. Hoffman, "DNS Resolver Information Self-
-              publication", draft-pp-add-resinfo-02 (work in progress),
-              June 2020.
+   [I-D.pauly-add-deer]
+              Pauly, T., Kinnear, E., Wood, C., McManus, P., and T.
+              Jensen, "Discovery of Equivalent Encrypted Resolvers",
+              draft-pauly-add-deer-00 (work in progress), November 2020.
 
    [I-D.pusateri-dhc-dns-driu]
               Pusateri, T. and W. Toorop, "DHCPv6 Options for private
@@ -1560,16 +1550,6 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               controller/technotes/8-5/
               b_Identity_PSK_Feature_Deployment_Guide.html>.
 
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 28]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
    [RFC3552]  Rescorla, E. and B. Korver, "Guidelines for Writing RFC
               Text on Security Considerations", BCP 72, RFC 3552,
               DOI 10.17487/RFC3552, July 2003,
@@ -1579,6 +1559,16 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               Host Configuration Protocol for IPv6 (DHCPv6)", RFC 3646,
               DOI 10.17487/RFC3646, December 2003,
               <https://www.rfc-editor.org/info/rfc3646>.
+
+
+
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 28]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    [RFC6092]  Woodyatt, J., Ed., "Recommended Simple Security
               Capabilities in Customer Premises Equipment (CPE) for
@@ -1619,13 +1609,6 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               RFC 7610, DOI 10.17487/RFC7610, August 2015,
               <https://www.rfc-editor.org/info/rfc7610>.
 
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 29]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
    [RFC7858]  Hu, Z., Zhu, L., Heidemann, J., Mankin, A., Wessels, D.,
               and P. Hoffman, "Specification for DNS over Transport
               Layer Security (TLS)", RFC 7858, DOI 10.17487/RFC7858, May
@@ -1635,6 +1618,13 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               Configuration on the Basis of Network Topology", RFC 7969,
               DOI 10.17487/RFC7969, October 2016,
               <https://www.rfc-editor.org/info/rfc7969>.
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 29]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    [RFC8146]  Harkins, D., "Adding Support for Salted Password Databases
               to EAP-pwd", RFC 8146, DOI 10.17487/RFC8146, April 2017,
@@ -1672,22 +1662,25 @@ Internet-Draft       Encrypted DNS in Home Networks        November 2020
               December 2018, <https://www.broadband-
               forum.org/technical/download/TR-069.pdf>.
 
-
-
-
-
-
-Boucadair, et al.          Expires May 6, 2021                 [Page 30]
-
-Internet-Draft       Encrypted DNS in Home Networks        November 2020
-
-
    [TS.24008]
               3GPP, "Mobile radio interface Layer 3 specification; Core
               network protocols; Stage 3 (Release 16)", December 2019,
               <http://www.3gpp.org/DynaReport/24008.htm>.
 
 Authors' Addresses
+
+
+
+
+
+
+
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 30]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    Mohamed Boucadair
    Orange
@@ -1720,6 +1713,11 @@ Authors' Addresses
    Email: neil.cook@noware.co.uk
 
 
+   Tommy Jensen
+   Microsoft
+   USA
+
+   Email: tojens@microsoft.com
 
 
 
@@ -1733,4 +1731,6 @@ Authors' Addresses
 
 
 
-Boucadair, et al.          Expires May 6, 2021                 [Page 31]
+
+
+Boucadair, et al.         Expires July 9, 2021                 [Page 31]

--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -5,14 +5,14 @@
 ADD                                                         M. Boucadair
 Internet-Draft                                                    Orange
 Intended status: Standards Track                                T. Reddy
-Expires: July 10, 2021                                            McAfee
+Expires: July 12, 2021                                            McAfee
                                                                  D. Wing
                                                                   Citrix
                                                                  N. Cook
                                                             Open-Xchange
                                                                T. Jensen
                                                                Microsoft
-                                                         January 6, 2021
+                                                         January 8, 2021
 
 
 DHCP and Router Advertisement Options for Encrypted DNS Discovery within
@@ -45,7 +45,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 10, 2021.
+   This Internet-Draft will expire on July 12, 2021.
 
 
 
@@ -53,7 +53,7 @@ Status of This Memo
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 1]
+Boucadair, et al.         Expires July 12, 2021                 [Page 1]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -97,19 +97,19 @@ Table of Contents
        7.1.3.  Auto-Upgrade Based on Domains and their Subdomains  .  20
      7.2.  Unmanaged CPEs  . . . . . . . . . . . . . . . . . . . . .  21
    8.  Legacy CPEs . . . . . . . . . . . . . . . . . . . . . . . . .  22
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  22
-     9.1.  Spoofing Attacks  . . . . . . . . . . . . . . . . . . . .  22
-     9.2.  Deletion Attacks  . . . . . . . . . . . . . . . . . . . .  23
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  23
+     9.1.  Spoofing Attacks  . . . . . . . . . . . . . . . . . . . .  23
+     9.2.  Deletion Attacks  . . . . . . . . . . . . . . . . . . . .  24
      9.3.  Passive Attacks . . . . . . . . . . . . . . . . . . . . .  24
      9.4.  Wireless Security - Authentication Attacks  . . . . . . .  24
-   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  24
-     10.1.  DHCPv6 Options . . . . . . . . . . . . . . . . . . . . .  24
+   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
+     10.1.  DHCPv6 Options . . . . . . . . . . . . . . . . . . . . .  25
      10.2.  DHCP Option  . . . . . . . . . . . . . . . . . . . . . .  25
      10.3.  RA Options . . . . . . . . . . . . . . . . . . . . . . .  25
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 2]
+Boucadair, et al.         Expires July 12, 2021                 [Page 2]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -165,7 +165,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 3]
+Boucadair, et al.         Expires July 12, 2021                 [Page 3]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -221,7 +221,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 4]
+Boucadair, et al.         Expires July 12, 2021                 [Page 4]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -277,7 +277,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 5]
+Boucadair, et al.         Expires July 12, 2021                 [Page 5]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -333,7 +333,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 6]
+Boucadair, et al.         Expires July 12, 2021                 [Page 6]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -389,7 +389,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 7]
+Boucadair, et al.         Expires July 12, 2021                 [Page 7]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -445,7 +445,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 8]
+Boucadair, et al.         Expires July 12, 2021                 [Page 8]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -501,7 +501,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                 [Page 9]
+Boucadair, et al.         Expires July 12, 2021                 [Page 9]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -557,7 +557,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 10]
+Boucadair, et al.         Expires July 12, 2021                [Page 10]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -613,7 +613,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 11]
+Boucadair, et al.         Expires July 12, 2021                [Page 11]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -669,7 +669,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 12]
+Boucadair, et al.         Expires July 12, 2021                [Page 12]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -725,7 +725,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 13]
+Boucadair, et al.         Expires July 12, 2021                [Page 13]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -781,7 +781,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 14]
+Boucadair, et al.         Expires July 12, 2021                [Page 14]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -837,7 +837,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 15]
+Boucadair, et al.         Expires July 12, 2021                [Page 15]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -893,7 +893,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 16]
+Boucadair, et al.         Expires July 12, 2021                [Page 16]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -949,7 +949,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 17]
+Boucadair, et al.         Expires July 12, 2021                [Page 17]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
@@ -978,9 +978,11 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    Upon discovery of a DoH resolver (Section 4), the DoH client may
    contact that DoH resolver to retrieve the list of supported DoH
    services using DEER [I-D.pauly-add-deer].  This will allow the client
-   to discover the resolver's supported DoH templates (or DoH resolvers
-   that the discovered resolver designates) using DNS SVCB queries
-   [I-D.schwartz-svcb-dns].
+   to discover the resolver's supported DoH templates or DoH resolvers
+   that the discovered resolver designates using DNS SVCB queries
+   [I-D.schwartz-svcb-dns].  The designated DoH resolvers and DoH
+   resolver discovered using DHCP/RA may be hosted on the same or
+   distinct IP addresses.
 
    Let's suppose that a host has discovered an encrypted DNS server that
    is DoH-capable.  The host has also discovered the following
@@ -995,20 +997,22 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    addition to the checks included in DEER, clients should verify the
    ADN is valid for the certificate provided by the DoH resolver.
    However, the IP address of the DEER-discovered resolver may differ
-   from the Locator field value.  This will allow home networks to refer
-   clients to resolvers known by name even if the current IP address of
-   that resolver is not known.
+   from the Locator field value.  This will allow the ISP to offer
+   different DoH services to the endpoints attached to home networks.
+
+
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 18]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
    Alternatively, dedicated DHCP/RA options may be defined to convey an
    URI template to avoid additional network traffic to bootstrap DoH
    configuration.  An example of such option is depicted in Figure 16.
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 18]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
        0                   1                   2                   3
        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1055,17 +1059,15 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
       client auto-upgrades to establish an encrypted a DoH/DoT/DoQ
       session with the ADN.
 
-      In such case, the DNS client matches the domain name in the
-      Encrypted DNS DHCP/RA option with the 'DNS-ID' identifier type
 
 
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 19]
+Boucadair, et al.         Expires July 12, 2021                [Page 19]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
+      In such case, the DNS client matches the domain name in the
+      Encrypted DNS DHCP/RA option with the 'DNS-ID' identifier type
       within subjectAltName entry in the server certificate conveyed in
       the TLS handshake.
 
@@ -1112,16 +1114,16 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    Let's suppose that "*.example.net" is pre-configured as a verified
    resolved in the browser or OS.  If the encrypted DNS client discovers
    a local forwarder "cpe1-internal.example.net", the encrypted DNS
-   client will auto-upgrade because the pre-configured ADN would match
-   subjectAltName value "cpe1-internal.example.net" of type dNSName.  As
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 20]
+Boucadair, et al.         Expires July 12, 2021                [Page 20]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
 
+   client will auto-upgrade because the pre-configured ADN would match
+   subjectAltName value "cpe1-internal.example.net" of type dNSName.  As
    shown in Figure 17, the auto-upgrade to a rogue server advertising
    "rs.example.org" will fail because it does not match "*.example.net".
 
@@ -1167,16 +1169,17 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    o  The encrypted DNS forwarder will either be configured to use the
       ISP's or a 3rd party encrypted DNS server.
 
-   o  The unmanaged CPE will advertise the encrypted DNS forwarder ADN
-      using DHCP/RA to internal hosts.
 
 
 
 
-Boucadair, et al.         Expires July 10, 2021                [Page 21]
+Boucadair, et al.         Expires July 12, 2021                [Page 21]
 
 Internet-Draft       Encrypted DNS in Home Networks         January 2021
 
+
+   o  The unmanaged CPE will advertise the encrypted DNS forwarder ADN
+      using DHCP/RA to internal hosts.
 
    Figure 18 illustrates an example of an unmanaged CPE hosting a
    forwarder which connects to a 3rd party encrypted DNS server.  In
@@ -1210,13 +1213,26 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    server and to retrieve the list of supported DoH services using the
    SVCB RRtype [I-D.schwartz-svcb-dns] without verifying the hostname of
    discovered templates with the ADN.  Other guidance in DEER relating
-   to resolver verification must be followed in this case.
+   to resolver verification must be followed in this case.  This will
+   prevent an unencrypted resolver on a local address from referring to
+   an encrypted resolver at a different address without an out-of-band
+   configuration in the client beyond the scope of this document or
+   DEER.
 
    The DHCP/RA option to discover DoH templates from DHCP or RA options
    (should the WG pursue that approach pending feedback) takes
    precedence over DEER since DEER uses unencrypted DNS to an external
    DNS resolver, which is susceptible to both internal and external
    attacks whereas DHCP/RA is only vulnerable to internal attacks.
+
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 22]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
 
 9.  Security Considerations
 
@@ -1226,14 +1242,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    within the LAN.  Unless mitigated (described below), the content of
    DHCP and RA messages can be spoofed or modified by active attackers,
    such as compromised devices within the home network.  An active
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 22]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
-
    attacker (Section 3.3 of [RFC3552]) can spoof the DHCP/RA response to
    provide the attacker's Encrypted DNS server.  Note that such an
    attacker can launch other attacks as discussed in Section 22 of
@@ -1271,6 +1279,17 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    behavior adheres to REQ#8 in [RFC6092]; it MUST apply for both IPv4
    and IPv6.
 
+
+
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 23]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
 9.2.  Deletion Attacks
 
    If the DHCP responses or RAs are dropped by the attacker, the client
@@ -1279,16 +1298,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    document.
 
    Note that deletion attack is not specific to DHCP/RA.
-
-
-
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 23]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
 9.3.  Passive Attacks
 
@@ -1325,26 +1334,24 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    keys can be created for each such device and WPA-PSK is used (e.g.,
    [PSK]).
 
+
+
+
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 24]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
 10.  IANA Considerations
 
 10.1.  DHCPv6 Options
 
    IANA is requested to assign the following new DHCPv6 Option Code in
    the registry maintained in [DHCPV6].
-
-
-
-
-
-
-
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 24]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
    +-------+-------------------+---------+------------+----------------+
    | Value | Description       | Client  | Singleton  | Reference      |
@@ -1386,6 +1393,15 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    Many thanks to Christian Jacquenet and Michael Richardson for the
    review.
 
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 25]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    Thanks to Stephen Farrell, Martin Thomson, Vittorio Bertola, Stephane
    Bortzmeyer, Ben Schwartz, and Iain Sharp for the comments.
 
@@ -1394,13 +1410,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    The use of DHCP to retrieve an authentication domain name was
    discussed in Section 7.3.1 of [RFC8310] and
    [I-D.pusateri-dhc-dns-driu].
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 25]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
 12.  Contributing Authors
 
@@ -1438,6 +1447,17 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               RFC 8106, DOI 10.17487/RFC8106, March 2017,
               <https://www.rfc-editor.org/info/rfc8106>.
 
+
+
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 26]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
               Writing an IANA Considerations Section in RFCs", BCP 26,
               RFC 8126, DOI 10.17487/RFC8126, June 2017,
@@ -1446,17 +1466,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
-
-
-
-
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 26]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
    [RFC8310]  Dickinson, S., Gillmor, D., and T. Reddy, "Usage Profiles
               for DNS over TLS and DNS over DTLS", RFC 8310,
@@ -1495,6 +1504,16 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               Dragonfly Handshake of WPA3 and EAP-pwd",
               <https://papers.mathyvanhoef.com/dragonblood.pdf>.
 
+
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 27]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    [Evil-Twin]
               The Unicode Consortium, "Evil twin (wireless networks)",
               <https://en.wikipedia.org/wiki/
@@ -1504,15 +1523,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               Box, C., Pauly, T., Wood, C., Reddy.K, T., and D. Migault,
               "Requirements for Adaptive DNS Discovery", draft-box-add-
               requirements-01 (work in progress), November 2020.
-
-
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 27]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
    [I-D.ietf-dnsop-terminology-ter]
               Hoffman, P., "Terminology for DNS Transports and
@@ -1550,6 +1560,16 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    [ND]       , <http://www.iana.org/assignments/icmpv6-parameters/
               icmpv6-parameters.xhtml#icmpv6-parameters-5>.
 
+
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 28]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    [PSK]      Cisco, "Identity PSK Feature Deployment Guide",
               <https://www.cisco.com/c/en/us/td/docs/wireless/
               controller/technotes/8-5/
@@ -1559,16 +1579,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               Text on Security Considerations", BCP 72, RFC 3552,
               DOI 10.17487/RFC3552, July 2003,
               <https://www.rfc-editor.org/info/rfc3552>.
-
-
-
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 28]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
    [RFC3646]  Droms, R., Ed., "DNS Configuration options for Dynamic
               Host Configuration Protocol for IPv6 (DHCPv6)", RFC 3646,
@@ -1609,6 +1619,13 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               RFC 7513, DOI 10.17487/RFC7513, May 2015,
               <https://www.rfc-editor.org/info/rfc7513>.
 
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 29]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    [RFC7610]  Gont, F., Liu, W., and G. Van de Velde, "DHCPv6-Shield:
               Protecting against Rogue DHCPv6 Servers", BCP 199,
               RFC 7610, DOI 10.17487/RFC7610, August 2015,
@@ -1618,13 +1635,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               and P. Hoffman, "Specification for DNS over Transport
               Layer Security (TLS)", RFC 7858, DOI 10.17487/RFC7858, May
               2016, <https://www.rfc-editor.org/info/rfc7858>.
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 29]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
    [RFC7969]  Lemon, T. and T. Mrugalski, "Customizing DHCP
               Configuration on the Basis of Network Topology", RFC 7969,
@@ -1663,6 +1673,15 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               (ACME)", RFC 8555, DOI 10.17487/RFC8555, March 2019,
               <https://www.rfc-editor.org/info/rfc8555>.
 
+
+
+
+
+Boucadair, et al.         Expires July 12, 2021                [Page 30]
+
+Internet-Draft       Encrypted DNS in Home Networks         January 2021
+
+
    [TR-069]   The Broadband Forum, "CPE WAN Management Protocol",
               December 2018, <https://www.broadband-
               forum.org/technical/download/TR-069.pdf>.
@@ -1671,16 +1690,6 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
               3GPP, "Mobile radio interface Layer 3 specification; Core
               network protocols; Stage 3 (Release 16)", December 2019,
               <http://www.3gpp.org/DynaReport/24008.htm>.
-
-
-
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 30]
-
-Internet-Draft       Encrypted DNS in Home Networks         January 2021
-
 
 Authors' Addresses
 
@@ -1724,13 +1733,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-Boucadair, et al.         Expires July 10, 2021                [Page 31]
+Boucadair, et al.         Expires July 12, 2021                [Page 31]

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -102,6 +102,20 @@
         <email>neil.cook@noware.co.uk</email>
       </address>
     </author>
+	
+	<author fullname="Tommy Jensen" initials="T." surname="Jensen">
+      <organization>Microsoft</organization>
+
+      <address>
+        <postal>
+          <street></street>
+
+          <country>USA</country>
+        </postal>
+
+        <email>tojens@microsoft.com</email>
+      </address>
+    </author>
 
     <date />
 
@@ -885,9 +899,10 @@ Host--(  Network#A  CPE----CPE---(   ISP   )--- DNS Server
       by a DoH server.</t>
 
       <t>Upon discovery of a DoH resolver (<xref target="RI"></xref>), the DoH
-      client may contact that DoH server to retrieve the list of supported DoH
-      services using the well-known URI. DoH clients repeats that request
-      regularly to retrieve an updated list of supported DoH services.</t>
+      client may contact that DoH resolver to retrieve the list of supported DoH
+      services using DEER <xref target="I-D.pauly-add-deer"></xref>. This will
+	  allow the client to discover the resolver's supported DoH templates (or DoH
+	  resolvers the discovered resolver designates) using DNS SVCB queries.</t>
 
       <t>Let's suppose that a host has discovered an encrypted DNS server that
       is DoH-capable. The host has also discovered the following
@@ -899,13 +914,20 @@ Host--(  Network#A  CPE----CPE---(   ISP   )--- DNS Server
           <t>Locator: 2001:db8:1::1</t>
         </list></t>
 
-      <t>The client requests "https://doh.example.com/.well-known/resinfo" to
-      retrieve the list of the URI Templates associated with this discovered
-      server.</t>
+      <t>The client will use DEER <xref target="I-D.pauly-add-deer"></xref> to
+	  discover the DoH templates supported by 
+	  the DNS server at the Locator address. In addition to the checks included
+	  in DEER, clients should verify the ADN matches the hostname in the
+	  DEER-provided templates. The IP address of the DEER-discovered resolver
+	  may differ from the Locator field value so long as the domain name matches
+	  the ADN. This will allow ISPs to have local forwarders send clients to
+	  off-network but ISP-owned resolvers whose IP address may not be known in
+	  advance.</t>
 
       <t>Alternatively, dedicated DHCP/RA options may be defined to convey an
-      URI template. An example of such option is depicted in <xref
-      target="uri"></xref>.</t>
+      URI template to avoid additional network traffic to bootstrap DoH
+	  configuration. An example of such option is depicted in
+	  <xref target="uri"></xref>.</t>
 
       <figure anchor="uri" title="Example of a DHCPv6 URI Template Option">
         <artwork><![CDATA[    0                   1                   2                   3
@@ -1083,27 +1105,19 @@ Legend:
       <t>Hosts serviced by legacy CPEs that can't be upgraded to support the
       options defined in <xref target="RI"></xref> won't be able to learn the
       encrypted DNS server hosted by the ISP, in particular. If the ADN is not
-      discovered using DHCP/RA, such hosts will have to fallback to use the
-      special-use domain name defined in <xref
-      target="I-D.pp-add-resinfo"></xref> to discover the encrypted DNS server
-      and to retrieve the list of supported DoH services using the RESINFO
-      RRtype <xref target="I-D.pp-add-resinfo"></xref>.</t>
+      discovered using DHCP/RA, such hosts will have to fallback to use DEER 
+      as defined in <xref
+      target="I-D.pauly-add-deer"></xref> to discover the encrypted DNS server
+      and to retrieve the list of supported DoH services using the SVCB
+      RRtype <xref target="I-D.pauly-add-deer"></xref> without verifying the
+	  hostname of discovered templates with the ADN. Other guidance in DEER
+	  relating to resolver verification must be followed in this case.</t>
 
-      <t>If the Do53 and Encrypted DNS servers are hosted on different public
-      IP addresses, the DNS server certificate can include the IP address of
-      the Do53 server in the subjectAltName extension. After validating the
-      server certificate, the client can retrieve the IP address in the
-      certificate to identify that both Do53 and Encrypted DNS servers are
-      operated by the same entity.</t>
-
-      <t>If the Do53 and Encrypted DNS server are hosted on a private IP
-      address, they should use the same private IP address to prove to the
-      client they are operated by the same entity.</t>
-
-      <t>The DHCP/RA option to discover ADN takes precedence over special-use
-      domain name since the special-use domain name is susceptible to both
-      internal and external attacks whereas DHCP/RA is only vulnerable to
-      internal attacks.</t>
+      <t>The DHCP/RA option to discover DoH templates from DHCP or RA options
+	  (should the WG pursue that approach pending feedback) takes precedence
+	  over DEER since it may use unencrypted DNS to a public resolver, which
+	  is susceptible to both internal and external attacks whereas DHCP/RA is 
+	  only vulnerable to internal attacks.</t>
     </section>
 
     <section anchor="Security" title="Security Considerations">
@@ -1365,8 +1379,8 @@ Legend:
       <?rfc include='reference.I-D.ietf-v6ops-rfc7084-bis' ?>
 
       <?rfc include='reference.I-D.ietf-dnsop-terminology-ter'?>
-
-      <?rfc include='reference.I-D.pp-add-resinfo'?>
+	  
+	  <?rfc include='reference.I-D.pauly-add-deer'?>
 
       <?rfc include='reference.RFC.6731'?>
 

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -902,7 +902,8 @@ Host--(  Network#A  CPE----CPE---(   ISP   )--- DNS Server
       client may contact that DoH resolver to retrieve the list of supported DoH
       services using DEER <xref target="I-D.pauly-add-deer"></xref>. This will
 	  allow the client to discover the resolver's supported DoH templates (or DoH
-	  resolvers the discovered resolver designates) using DNS SVCB queries.</t>
+	  resolvers that the discovered resolver designates) using DNS SVCB queries
+	  <xref target="I-D.schwartz-svcb-dns"></xref>.</t>
 
       <t>Let's suppose that a host has discovered an encrypted DNS server that
       is DoH-capable. The host has also discovered the following
@@ -1109,7 +1110,7 @@ Legend:
       as defined in <xref
       target="I-D.pauly-add-deer"></xref> to discover the encrypted DNS server
       and to retrieve the list of supported DoH services using the SVCB
-      RRtype <xref target="I-D.pauly-add-deer"></xref> without verifying the
+      RRtype <xref target="I-D.schwartz-svcb-dns"></xref> without verifying the
 	  hostname of discovered templates with the ADN. Other guidance in DEER
 	  relating to resolver verification must be followed in this case.</t>
 
@@ -1381,6 +1382,8 @@ Legend:
       <?rfc include='reference.I-D.ietf-dnsop-terminology-ter'?>
 	  
 	  <?rfc include='reference.I-D.pauly-add-deer'?>
+	  
+	  <?rfc include='reference.I-D.schwartz-svcb-dns'?>
 
       <?rfc include='reference.RFC.6731'?>
 

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -901,9 +901,11 @@ Host--(  Network#A  CPE----CPE---(   ISP   )--- DNS Server
       <t>Upon discovery of a DoH resolver (<xref target="RI"></xref>), the DoH
       client may contact that DoH resolver to retrieve the list of supported DoH
       services using DEER <xref target="I-D.pauly-add-deer"></xref>. This will
-	  allow the client to discover the resolver's supported DoH templates (or DoH
-	  resolvers that the discovered resolver designates) using DNS SVCB queries
-	  <xref target="I-D.schwartz-svcb-dns"></xref>.</t>
+	  allow the client to discover the resolver's supported DoH templates or DoH
+	  resolvers that the discovered resolver designates using DNS SVCB queries
+	  <xref target="I-D.schwartz-svcb-dns"></xref>. The designated DoH resolvers
+	  and DoH resolver discovered using DHCP/RA may be hosted on the same or
+	  distinct IP addresses.</t>
 
       <t>Let's suppose that a host has discovered an encrypted DNS server that
       is DoH-capable. The host has also discovered the following
@@ -921,8 +923,8 @@ Host--(  Network#A  CPE----CPE---(   ISP   )--- DNS Server
 	  in DEER, clients should verify the ADN is valid for the certificate
 	  provided by the DoH resolver. However, the IP address of the
 	  DEER-discovered resolver may differ from the Locator field value. This
-	  will allow home networks to refer clients to resolvers known by name even
-	  if the current IP address of that resolver is not known.</t>
+	  will allow the ISP to offer different DoH services to the endpoints
+	  attached to home networks.</t>
 
       <t>Alternatively, dedicated DHCP/RA options may be defined to convey an
       URI template to avoid additional network traffic to bootstrap DoH
@@ -1111,7 +1113,10 @@ Legend:
       and to retrieve the list of supported DoH services using the SVCB
       RRtype <xref target="I-D.schwartz-svcb-dns"></xref> without verifying the
 	  hostname of discovered templates with the ADN. Other guidance in DEER
-	  relating to resolver verification must be followed in this case.</t>
+	  relating to resolver verification must be followed in this case. This
+	  will prevent an unencrypted resolver on a local address from referring
+	  to an encrypted resolver at a different address without an out-of-band
+	  configuration in the client beyond the scope of this document or DEER.</t>
 
       <t>The DHCP/RA option to discover DoH templates from DHCP or RA options
 	  (should the WG pursue that approach pending feedback) takes precedence

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -1306,8 +1306,8 @@ Legend:
       <t>Many thanks to Christian Jacquenet and Michael Richardson for the
       review.</t>
 
-      <t>Thanks to Tommy Jensen, Stephen Farrell, Martin Thomson, Vittorio
-      Bertola, Stephane Bortzmeyer, Ben Schwartz, and Iain Sharp for the
+      <t>Thanks to Stephen Farrell, Martin Thomson, Vittorio Bertola,
+      Stephane Bortzmeyer, Ben Schwartz, and Iain Sharp for the
       comments.</t>
 
       <t>Thanks to Mark Nottingham for the feedback on HTTP redirection.</t>

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -1116,9 +1116,9 @@ Legend:
 
       <t>The DHCP/RA option to discover DoH templates from DHCP or RA options
 	  (should the WG pursue that approach pending feedback) takes precedence
-	  over DEER since it may use unencrypted DNS to a public resolver, which
-	  is susceptible to both internal and external attacks whereas DHCP/RA is 
-	  only vulnerable to internal attacks.</t>
+	  over DEER since it uses unencrypted DNS to an external DNS resolver,
+	  which is susceptible to both internal and external attacks whereas
+	  DHCP/RA is only vulnerable to internal attacks.</t>
     </section>
 
     <section anchor="Security" title="Security Considerations">

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -918,12 +918,12 @@ Host--(  Network#A  CPE----CPE---(   ISP   )--- DNS Server
       <t>The client will use DEER <xref target="I-D.pauly-add-deer"></xref> to
 	  discover the DoH templates supported by 
 	  the DNS server at the Locator address. In addition to the checks included
-	  in DEER, clients should verify the ADN matches the hostname in the
-	  DEER-provided templates. The IP address of the DEER-discovered resolver
-	  may differ from the Locator field value so long as the domain name matches
-	  the ADN. This will allow ISPs to have local forwarders send clients to
-	  off-network but ISP-owned resolvers whose IP address may not be known in
-	  advance.</t>
+	  in DEER, clients should verify the ADN is valid for the certificate
+	  provided by the DoH resolver. The IP address of the DEER-discovered
+	  resolver may differ from the Locator field value so long as the domain
+	  name matches the ADN. This will allow home networks to refer clients to
+	  resolvers known by name even if the current IP address of that resolver
+	  is not known.</t>
 
       <t>Alternatively, dedicated DHCP/RA options may be defined to convey an
       URI template to avoid additional network traffic to bootstrap DoH
@@ -1116,7 +1116,7 @@ Legend:
 
       <t>The DHCP/RA option to discover DoH templates from DHCP or RA options
 	  (should the WG pursue that approach pending feedback) takes precedence
-	  over DEER since it uses unencrypted DNS to an external DNS resolver,
+	  over DEER since DEER uses unencrypted DNS to an external DNS resolver,
 	  which is susceptible to both internal and external attacks whereas
 	  DHCP/RA is only vulnerable to internal attacks.</t>
     </section>

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -919,11 +919,10 @@ Host--(  Network#A  CPE----CPE---(   ISP   )--- DNS Server
 	  discover the DoH templates supported by 
 	  the DNS server at the Locator address. In addition to the checks included
 	  in DEER, clients should verify the ADN is valid for the certificate
-	  provided by the DoH resolver. The IP address of the DEER-discovered
-	  resolver may differ from the Locator field value so long as the domain
-	  name matches the ADN. This will allow home networks to refer clients to
-	  resolvers known by name even if the current IP address of that resolver
-	  is not known.</t>
+	  provided by the DoH resolver. However, the IP address of the
+	  DEER-discovered resolver may differ from the Locator field value. This
+	  will allow home networks to refer clients to resolvers known by name even
+	  if the current IP address of that resolver is not known.</t>
 
       <t>Alternatively, dedicated DHCP/RA options may be defined to convey an
       URI template to avoid additional network traffic to bootstrap DoH


### PR DESCRIPTION
Modified Sections 5 and 8 to clarify how this draft and DEER coexist so that both direct discovery from the network and bootstrapping from only an IP address are defined for encrypted DNS clients cohesively.