### PR TITLE
Removed reference to server policy left over from previous versions

### DIFF
--- a/draft-btw-add-home.txt
+++ b/draft-btw-add-home.txt
@@ -965,12 +965,11 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    attacker (Section 3.3 of [RFC3552]) can spoof the DHCP/RA response to
    provide the attacker's Encrypted DNS server.  Note that such an
    attacker can launch other attacks as discussed in Section 22 of
-   [RFC8415].  The attacker can get a domain name, domain-validated
-   public certificate from a CA, host an Encrypted DNS server and claim
-   the best DNS privacy preservation policy.  Also, an attacker can use
-   a public IP address, get an 'IP address'-validated public certificate
-   from a CA, host an Encrypted DNS server and claim the best DNS
-   privacy preservation policy.
+   [RFC8415].  The attacker can get a domain name with a domain-
+   validated public certificate from a CA and host an Encrypted DNS
+   server.  Also, an attacker can use a public IP address and get an 'IP
+   address'-validated public certificate from a CA to host an Encrypted
+   DNS server.
 
    Attacks of spoofed or modified DHCP responses and RA messages by
    attackers within the local network may be mitigated by making use of
@@ -998,6 +997,7 @@ Internet-Draft       Encrypted DNS in Home Networks         January 2021
    MUST be discarded by the encrypted DNS forwarder in the CPE.  This
    behavior adheres to REQ#8 in [RFC6092]; it MUST apply for both IPv4
    and IPv6.
+
 
 
 

--- a/draft-btw-add-home.xml
+++ b/draft-btw-add-home.xml
@@ -898,12 +898,10 @@ Legend:
         spoof the DHCP/RA response to provide the attacker's Encrypted DNS
         server. Note that such an attacker can launch other attacks as
         discussed in Section 22 of <xref target="RFC8415"></xref>. The
-        attacker can get a domain name, domain-validated public certificate
-        from a CA, host an Encrypted DNS server and claim the best DNS privacy
-        preservation policy. Also, an attacker can use a public IP address,
-        get an 'IP address'-validated public certificate from a CA, host an
-        Encrypted DNS server and claim the best DNS privacy preservation
-        policy.</t>
+        attacker can get a domain name with a domain-validated public
+		certificate from a CA and host an Encrypted DNS server. Also, an
+		attacker can use a public IP address and get an 'IP address'-validated
+		public certificate from a CA to host an Encrypted DNS server.</t>
 
         <t>Attacks of spoofed or modified DHCP responses and RA messages by
         attackers within the local network may be mitigated by making use of


### PR DESCRIPTION
As discussed on email from the original DEER edits. I was reminded this needed done when the chairs issued their suggested changes.